### PR TITLE
Convert XMP parser classes to use XDocument (Issue #4)

### DIFF
--- a/XmpCore.Tests/XMPCoreCoverage.cs
+++ b/XmpCore.Tests/XMPCoreCoverage.cs
@@ -47,6 +47,9 @@ namespace XmpCore.Tests
             {
                 log.WriteLine("Caught exception '" + e.Message  + "'");
             }
+
+            if (log != null)
+                log.Flush();
         }
 
         private static void DoCoreCoverage()

--- a/XmpCore/XmpCore.csproj
+++ b/XmpCore/XmpCore.csproj
@@ -39,6 +39,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Impl\ByteBuffer.cs" />


### PR DESCRIPTION
First step to PCL support (Issue #4). Coverage output is still correct compared to previous code, and might be an improvement overall. Some of the code was refactored using Adobe's C++ implementation.