### PR TITLE
Don't dispose stream input to XmpSerializerRdf.Serialize

### DIFF
--- a/XmpCore/Impl/XmpSerializerRdf.cs
+++ b/XmpCore/Impl/XmpSerializerRdf.cs
@@ -108,7 +108,6 @@ namespace XmpCore.Impl
                 // writes the tail
                 Write(tailStr);
                 _writer.Flush();
-                _stream.Dispose();
             }
             catch (IOException)
             {


### PR DESCRIPTION
If disposed, XMPSerializerHelper.SerializeToString and SerializeToBuffer will fail