### PR TITLE
Add char overload for serialization Write

### DIFF
--- a/XmpCore/Impl/XmpSerializerRdf.cs
+++ b/XmpCore/Impl/XmpSerializerRdf.cs
@@ -1183,13 +1183,21 @@ namespace XmpCore.Impl
             }
         }
 
-        /// <summary>Writes a char to the output.</summary>
-        /// <param name="c">a char</param>
+        /// <summary>Writes a int to the output.</summary>
+        /// <param name="c">an int</param>
         /// <exception cref="System.IO.IOException">forwards writer exceptions</exception>
         private void Write(int c)
         {
             _writer.Write(c);
         }
+
+		/// <summary>Writes a char to the output.</summary>
+		/// <param name="c">a char</param>
+		/// <exception cref="System.IO.IOException">forwards writer exceptions</exception>
+		private void Write(char c)
+		{
+			_writer.Write(c);
+		}
 
         /// <summary>Writes a String to the output.</summary>
         /// <param name="str">a String</param>

--- a/XmpCore/Impl/XmpSerializerRdf.cs
+++ b/XmpCore/Impl/XmpSerializerRdf.cs
@@ -1183,7 +1183,7 @@ namespace XmpCore.Impl
             }
         }
 
-        /// <summary>Writes a int to the output.</summary>
+        /// <summary>Writes an int to the output.</summary>
         /// <param name="c">an int</param>
         /// <exception cref="System.IO.IOException">forwards writer exceptions</exception>
         private void Write(int c)


### PR DESCRIPTION
_writer.Write(c) with int was always writing the unicode value of the character instead of the character itself. (eg. Always the literal '34' instead of '"' on attribute terminations)