### PR TITLE
added methods for reading XDocuments

### DIFF
--- a/XmpCore/Impl/XmpMetaParser.cs
+++ b/XmpCore/Impl/XmpMetaParser.cs
@@ -65,6 +65,32 @@ namespace XmpCore.Impl
             var doc = ParseXmlString(xmlStr, options);
             return ParseXmlDoc(doc, options);
         }
+
+        /// <summary>
+        /// Parses an XMP metadata object from a XDocument, including de-aliasing and normalisation.
+        /// </summary>
+        /// <exception cref="XmpException">Thrown if parsing or normalisation fails.</exception>
+        public static IXmpMeta Parse(XDocument doc, ParseOptions options = null)
+        {
+            ParameterAsserts.AssertNotNull(doc);
+            options = options ?? new ParseOptions();
+            return ParseXmlDoc(doc, options);
+        }
+
+        /// <summary>
+        /// Parses XML from a byte buffer,
+        /// fixing the encoding (Latin-1 to UTF-8) and illegal control character optionally.
+        /// </summary>
+        /// <param name="buffer">a byte buffer containing the XMP packet</param>
+        /// <param name="options">the parsing options</param>
+        /// <returns>Returns an XML DOM-Document.</returns>
+        /// <exception cref="XmpException">Thrown when the parsing fails.</exception>
+        public static XDocument Extract(byte[] bytes, ParseOptions options = null)
+        {
+            ParameterAsserts.AssertNotNull(bytes);
+            options = options ?? new ParseOptions();
+            return ParseXmlFromByteBuffer(new ByteBuffer(bytes), options);
+        }
         
         private static IXmpMeta ParseXmlDoc(XDocument document, ParseOptions options)
         {

--- a/XmpCore/XMPMetaFactory.cs
+++ b/XmpCore/XMPMetaFactory.cs
@@ -10,6 +10,7 @@
 
 using System;
 using System.IO;
+using System.Xml.Linq;
 using XmpCore.Impl;
 using XmpCore.Options;
 
@@ -66,6 +67,10 @@ namespace XmpCore
         /// <returns>Returns the <c>XMPMeta</c>-object created from the input.</returns>
         /// <exception cref="XmpException">If the file is not well-formed XML or if the parsing fails.</exception>
         public static IXmpMeta ParseFromBuffer(byte[] buffer, ParseOptions options = null) => XmpMetaParser.Parse(buffer, options);
+
+        public static IXmpMeta ParseFromXDocument(XDocument root, ParseOptions options = null) => XmpMetaParser.Parse(root, options);
+
+        public static XDocument ExtractXDocumentFromBuffer(byte[] buffer, ParseOptions options = null) => XmpMetaParser.Extract(buffer, options);
 
         /// <summary>Serializes an <c>XMPMeta</c>-object as RDF into an <c>OutputStream</c>.</summary>
         /// <param name="xmp">a metadata object</param>


### PR DESCRIPTION
The first method allows reading of XDocuments from buffers, while the second parses XDocuments to IXmpMeta.
Both was already done in a single step before, but the implementation of writing XMP metadata that I am contributing as described in https://github.com/drewnoakes/metadata-extractor-dotnet/issues/23 works at the level of XDocuments.