### PR TITLE
Incorporate Java 5.1.3 changes to address XXE issues

### DIFF
--- a/XmpCore.Tests/ParseTests.cs
+++ b/XmpCore.Tests/ParseTests.cs
@@ -1,4 +1,6 @@
-﻿using Xunit;
+﻿using System;
+using System.Xml;
+using Xunit;
 
 namespace XmpCore.Tests
 {
@@ -27,6 +29,104 @@ namespace XmpCore.Tests
 </x:xmpmeta>";
 
             XmpMetaFactory.ParseFromString(xmpPacket);
+        }
+
+        [Fact]
+        public void XXE_DoctypeDisabled()
+        {
+            string testdata = @"<!DOCTYPE doc [<!ENTITY win SYSTEM ""c:\windows\win.ini"">]><doc></doc>";
+
+            // doctype not allowed by default
+            Assert.Throws<XmpException>(() => XmpMetaFactory.ParseFromString(testdata));
+        }
+
+        [Fact]
+        public void XXE_DoctypeEnabled()
+        {
+            string testdata = @"<!DOCTYPE doc [<!ENTITY win SYSTEM ""c:\windows\win.ini"">]><doc></doc>";
+
+            var options = new Options.ParseOptions();
+
+            // enable doctype
+            options.DisallowDoctype = false;
+            Exception e = null;
+            try
+            {
+                XmpMetaFactory.ParseFromString(testdata, options);
+            }
+            catch (Exception ex)
+            {
+                e = ex;
+            }
+            Assert.Null(e);
+        }
+
+        [Fact]
+        public void BillionLaughs_DoctypeDisabled()
+        {
+            var testdata = @"<?xml version=""1.0""?>
+                <!DOCTYPE lolz [
+                <!ENTITY lol ""lol"">
+                <!ENTITY lol2 ""&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;"">
+                <!ENTITY lol3 ""&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;"">
+                <!ENTITY lol4 ""&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;"">
+                <!ENTITY lol5 ""&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;"">
+                <!ENTITY lol6 ""&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;"">
+                <!ENTITY lol7 ""&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;"">
+                <!ENTITY lol8 ""&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;"">
+                <!ENTITY lol9 ""&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;"">
+                ]>
+                <lolz>&lol9;</lolz>";
+
+            XmpException e = null;
+            try
+            {
+                // doctype not allowed by default
+                XmpMetaFactory.ParseFromString(testdata);
+            }
+            catch (XmpException ex)
+            {
+                e = ex;
+            }
+
+            Assert.NotNull(e);
+            Assert.True(e.InnerException.Message.StartsWith("For security reasons DTD is prohibited"));
+        }
+
+        [Fact]
+        public void BillionLaughs_DoctypeEnabled()
+        {
+            var testdata = @"<?xml version=""1.0""?>
+                <!DOCTYPE lolz [
+                <!ENTITY lol ""lol"">
+                <!ENTITY lol2 ""&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;"">
+                <!ENTITY lol3 ""&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;"">
+                <!ENTITY lol4 ""&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;"">
+                <!ENTITY lol5 ""&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;"">
+                <!ENTITY lol6 ""&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;"">
+                <!ENTITY lol7 ""&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;"">
+                <!ENTITY lol8 ""&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;"">
+                <!ENTITY lol9 ""&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;"">
+                ]>
+                <lolz>&lol9;</lolz>";
+
+            var options = new Options.ParseOptions();
+            // enable doctype
+            options.DisallowDoctype = false;
+
+            XmpException e = null;
+            try
+            {
+                XmpMetaFactory.ParseFromString(testdata, options);
+            }
+            catch (XmpException ex)
+            {
+                e = ex;
+            }
+
+            Assert.NotNull(e);
+            Assert.True(e.InnerException.Message.StartsWith("The input document has exceeded a limit set by MaxCharactersFromEntities"));
+
         }
     }
 }

--- a/XmpCore/Options/ParseOptions.cs
+++ b/XmpCore/Options/ParseOptions.cs
@@ -30,10 +30,13 @@ namespace XmpCore.Options
         /// <summary>Do not carry run the XMPNormalizer on a packet, leave it as it is.</summary>
         private const int OmitNormalizationFlag = 0x0020;
 
+        /// <summary>Disallow DOCTYPE declarations to prevent entity expansion attacks.</summary>
+        public const int DisallowDoctypeFlag = 0x0040;
+
         /// <summary>Sets the options to the default values.</summary>
         public ParseOptions()
         {
-            SetOption(FixControlCharsFlag | AcceptLatin1Flag, true);
+            SetOption(FixControlCharsFlag | AcceptLatin1Flag | DisallowDoctypeFlag, true);
         }
 
         public bool RequireXmpMeta
@@ -62,8 +65,14 @@ namespace XmpCore.Options
 
         public bool OmitNormalization
         {
-            set { SetOption(OmitNormalizationFlag, value); }
             get { return GetOption(OmitNormalizationFlag); }
+            set { SetOption(OmitNormalizationFlag, value); }
+        }
+
+        public bool DisallowDoctype
+        {
+            get { return GetOption(DisallowDoctypeFlag); }
+            set { SetOption(DisallowDoctypeFlag, value); }
         }
 
         protected override string DefineOptionName(int option)
@@ -80,6 +89,8 @@ namespace XmpCore.Options
                     return "ACCEPT_LATIN_1";
                 case OmitNormalizationFlag:
                     return "OMIT_NORMALIZATION";
+                case DisallowDoctypeFlag:
+                    return "DISALLOW_DOCTYPE";
                 default:
                     return null;
             }
@@ -87,7 +98,7 @@ namespace XmpCore.Options
 
         protected override int GetValidOptions()
         {
-            return RequireXmpMetaFlag | StrictAliasingFlag | FixControlCharsFlag | AcceptLatin1Flag | OmitNormalizationFlag;
+            return RequireXmpMetaFlag | StrictAliasingFlag | FixControlCharsFlag | AcceptLatin1Flag | OmitNormalizationFlag | DisallowDoctypeFlag;
         }
     }
 }


### PR DESCRIPTION
The only changes from 5.1.2 to 5.1.3 in Java involve disabling certain processing properties to stop XXE issues. ParseOptions holds this new option and should be good. The changes for the parser though should be reviewed. It was a challenge to make sure the equivalent items in .NET were set, although in 4.0 and after more of the required settings have correct defaults. I created a few new tests as well but please sanity check.

Lastly, I wasn't able to test it with metadata extractor like I have in the past. The nuget requirement makes that more difficult. If you know of an easy way to reference local assemblies, I'm all ears.

https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet
https://www.jardinesoftware.net/2016/05/26/xxe-and-net/
