### PR TITLE
More XML attribute sorting to match Java output

### DIFF
--- a/XmpCore/Impl/XmpMetaParser.cs
+++ b/XmpCore/Impl/XmpMetaParser.cs
@@ -112,7 +112,8 @@ namespace XmpCore.Impl
             {
                 var orderedattribs = node.Attributes()
                                         .OrderBy(n => !n.IsNamespaceDeclaration)
-                                        .ThenBy(s => (node.GetPrefixOfNamespace(s.Name.Namespace) ?? "") + ":" + s.Name.LocalName);
+                                        .ThenBy(s => node.GetPrefixOfNamespace(s.Name.Namespace))
+                                        .ThenBy(s => s.Name.LocalName);
                 node.ReplaceAttributes(orderedattribs);
             }
 

--- a/XmpCore/Impl/XmpMetaParser.cs
+++ b/XmpCore/Impl/XmpMetaParser.cs
@@ -106,13 +106,13 @@ namespace XmpCore.Impl
 
         private static IXmpMeta ParseXmlDoc(XDocument document, ParseOptions options)
         {
-            // sort node Attributes to match Java
-            // (keep namespace declarations in the order they are, and then prefixed names after in prefix:localname order)
+            // sort node Attributes to match Java DocumentBuilder (attribute order isn't supposed to matter but DocumentBuilder does some sorting)
+            // namespace declarations come first, and then all are sorted in prefix:localname order
             foreach(var node in document.Descendants().Where(d => d.Attributes().Count() > 1))
             {
-                var declarations = node.Attributes().Where(n => n.IsNamespaceDeclaration);
-                var orderedattribs = declarations.Concat(node.Attributes().Where(n => !n.IsNamespaceDeclaration).OrderBy(s => (node.GetPrefixOfNamespace(s.Name.Namespace) ?? "") + ":" + s.Name.LocalName));
-
+                var orderedattribs = node.Attributes()
+                                        .OrderBy(n => !n.IsNamespaceDeclaration)
+                                        .ThenBy(s => (node.GetPrefixOfNamespace(s.Name.Namespace) ?? "") + ":" + s.Name.LocalName);
                 node.ReplaceAttributes(orderedattribs);
             }
 


### PR DESCRIPTION
Follow-up to #20.

Attribute sort order from Java DocumentBuilder appears to put all "xmlns" namespace declarations first, and then sorts everything on prefix+localname.

Leaning on LINQ a bit. I ran it through the images database and randomly checked. The output seems to be as expected but any extra testing would be great.

If any parse results from Java in the future don't match, we can revisit. The conditionals don't exclude any attribs, so worst case is the sort doesn't match; there shouldn't be any missing attribs.