### PR TITLE
Use Ordinal comparer when re-sorting attributes

### DIFF
--- a/XmpCore/Impl/XmpMetaParser.cs
+++ b/XmpCore/Impl/XmpMetaParser.cs
@@ -112,8 +112,8 @@ namespace XmpCore.Impl
             {
                 var orderedattribs = node.Attributes()
                                         .OrderBy(n => !n.IsNamespaceDeclaration)
-                                        .ThenBy(s => node.GetPrefixOfNamespace(s.Name.Namespace))
-                                        .ThenBy(s => s.Name.LocalName);
+                                        .ThenBy(t => node.GetPrefixOfNamespace(t.Name.Namespace), StringComparer.Ordinal)
+                                        .ThenBy(s => s.Name.LocalName, StringComparer.Ordinal);
                 node.ReplaceAttributes(orderedattribs);
             }
 


### PR DESCRIPTION
After further testing with Java, the sort was really close. All it needed was Ordinal (capitals first) instead of case-insensitive. My vote is to make another release from this since it finally feels like the correct sort, but up to you if it's worth it right now. I don't know what's involved in that.