### PR TITLE
Execute .net45 and .netcoreapp1.0 tests

### DIFF
--- a/XmpCore.Tests/XmpCore.Tests.csproj
+++ b/XmpCore.Tests/XmpCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>XmpCore.Tests</AssemblyName>
     <PackageId>XmpCore.Tests</PackageId>
@@ -21,7 +21,7 @@
     <PackageReference Include="xunit" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/XmpCore.sln
+++ b/XmpCore.sln
@@ -7,6 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		appveyor.yml = appveyor.yml
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ build:
 test:
   assemblies:
     - XmpCore.Tests.dll
+test_script:
+  - dotnet test .\XmpCore.Tests\XmpCore.Tests.csproj --configuration Release --no-build
 notifications:
 - provider: Email
   to:


### PR DESCRIPTION
When xUnit was releasing 2.2.0 they dropped support for net451, see https://xunit.github.io/release-notes/2017-02-19.html

This PR contains updated TFM to net452 that only is for test-project so the class library will still compuled for lower TFM. 

If not having the test_script` in `appveyor.yml` only the `net452` test is executing, with the `test_script` both test for `net452` and `netcoreapp1.0` is executed.