### PR TITLE
Fix ArgumentOutOfRangeException in XmpUtils.PackageForJPEG

### DIFF
--- a/XmpCore.Tests/XmpUtilsTests.cs
+++ b/XmpCore.Tests/XmpUtilsTests.cs
@@ -1,4 +1,6 @@
-﻿using Xunit;
+﻿using System.Text;
+using XmpCore.Impl;
+using Xunit;
 
 namespace XmpCore.Tests
 {
@@ -30,6 +32,19 @@ namespace XmpCore.Tests
 
             Assert.Throws<XmpException>(() => XmpUtils.ConvertToLong(null));
             Assert.Throws<XmpException>(() => XmpUtils.ConvertToLong("Foo"));
+        }
+
+        [Fact]
+        public void PackageEmptyXmpDataToJPEG()
+        {
+            IXmpMeta data = new XmpMeta();
+            StringBuilder standard = new StringBuilder();
+            StringBuilder extended = new StringBuilder();
+            StringBuilder digest = new StringBuilder();
+
+            XmpUtils.PackageForJPEG(data, standard, extended, digest);
+            
+            Assert.Equal(0, extended.Length);
         }
     }
 }

--- a/XmpCore/Impl/XmpUtils.cs
+++ b/XmpCore/Impl/XmpUtils.cs
@@ -1477,7 +1477,9 @@ namespace XmpCore.Impl
             if (extraPadding > 2047)
                 extraPadding = 2047;
             //stdStr.delete(stdStr.toString().indexOf(kPacketTrailer), stdStr.length());
-            stdStr.Remove(stdStr.ToString().IndexOf(kPacketTrailer), stdStr.Length);
+            int index = stdStr.ToString().IndexOf(kPacketTrailer);
+            int length = stdStr.Length - index;
+            stdStr.Remove(index, length);
 
             stdStr.Append(' ', extraPadding);
 


### PR DESCRIPTION
Current implementation of `XmpUtils.PackageForJPEG` throws `ArgumentOutOfRangeException` for all inputs. The error was likely caused by difference in StringBuilder API. In C#, `StringBuilder.Remove` expects position and length of the removed substring whereas in Java, `StringBuilder.delete` takes start and end indices.