### PR TITLE
Update testing libs

### DIFF
--- a/XmpCore.Tests/XmpCore.Tests.csproj
+++ b/XmpCore.Tests/XmpCore.Tests.csproj
@@ -6,9 +6,12 @@
     <ProjectReference Include="..\XmpCore\XmpCore.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi,

I tried running the unit tests is VS 2022, and they wouldn't run - there were errors like

```
========== Starting test discovery ==========
[xUnit.net 00:00:00.5809575]   Discovering: XmpCore.Tests
[xUnit.net 00:00:00.7641230]   Discovered:  XmpCore.Tests
[xUnit.net 00:00:00.0219840] Skipping: XmpCore.Tests (could not find dependent assembly 'Microsoft.Extensions.DependencyModel, Version=1.1.0')
========== Test discovery finished: 17 Tests found in 1.5 sec ==========
Not all tests from the test run selection could be discovered.
```

and as NuGet is also pointing out references to old libraries with security warnings:
![image](https://github.com/drewnoakes/xmp-core-dotnet/assets/1178570/151fd21b-81f1-43b8-8f40-fe2d0c216e37)

maybe they can be updated to newer versions?

Note: The test project is currently running as .NET 4.8 and .NET 5.0, but the latest versions of the xunit test runner (2.5.7) seems to have bumped the minimum supported version to .NET 6.0, so maybe the test project could be bumped to 6 as well?