### PR TITLE
Address bug with java port in the rdf:RDF element

### DIFF
--- a/XmpCore/Impl/ParseRdf.cs
+++ b/XmpCore/Impl/ParseRdf.cs
@@ -105,7 +105,7 @@ namespace XmpCore.Impl
         /// <exception cref="XmpException">thrown on parsing errors</exception>
         private static void Rdf_RDF(XmpMeta xmp, XElement rdfRdfNode, ParseOptions options)
         {
-            if (!rdfRdfNode.Attributes().Any())
+            if (rdfRdfNode.Attributes().Any(attr => attr.IsNamespaceDeclaration == false))
                 throw new XmpException("Invalid attributes of rdf:RDF element", XmpErrorCode.BadRdf);
 
             Rdf_NodeElementList(xmp, xmp.GetRoot(), rdfRdfNode, options);


### PR DESCRIPTION
* Updated ParseRdf.cs to align with the xmp spec where a namespace declaration in rdf:RDF is valid. There was an issue with java port as described here by @Numpsy: https://github.com/drewnoakes/metadata-extractor-dotnet/issues/418
* Added two unit tests to for the issue 
- 1. If rdf:RDF has namespace attribute, it should not throw an exception (as per the spec) 
- 2. If rdf:RDF has anything other than namespace attribute, it should throw an exception